### PR TITLE
introduces pytest and improves build/test/deploy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
 show_missing = True
-fail_under = 95
+fail_under = 80
 omit =
    .*

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@
 .*~
 
 # python cruft
+.cache
 .coverage
 .eggs
 *.egg-info
 *.pyc
 __pycache__
+build/
+dist/
 
 # db stuff
 *.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,7 @@ ENV PYTHONUNBUFFERED 1
 
 RUN mkdir /code
 WORKDIR /code
-
-COPY setup.py ./
-RUN python setup.py requirements
-
 COPY . ./
-RUN python setup.py develop
+RUN pip install -e .
+
 CMD run_prod

--- a/README.md
+++ b/README.md
@@ -1,70 +1,85 @@
-# crowdsourcing microservice
+# NYPR Crowdsourcing
 
-## development
+## Development
 
-### build the image
-`$ docker-compose build`
+### Getting started
 
-_Use this to rebuild the image if requirements or the Dockerfile change_
-
-### run the migrations
-`$ docker-compose run django ./manage.py migrate`
-
-### make yourself a superuser
-`$ docker-compose run django ./manage.py createsuperuser`
-
-### run
-`$ docker-compose up`
-
-### debug
-Use the `--service-ports` argument to enable breakpoints
-
-```python3
-# some code
-import ipdb; ipdb.set_trace()
+Clone the repo.
+```sh
+$ git clone git@github.com:nypublicradio/crowdsourcing
+$ cd crowdsourcing
 ```
 
-`$ docker-compose run --service-ports --rm django`
-
-### test
-`$ docker-compose run --rm django manage.py test`
-
-## production
-
-### settings to expose via environment variables
-
-#### aws keys
-```
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-AWS_DEFAULT_REGION
+Build the image.
+```sh
+$ docker-compose build
 ```
 
-#### aws s3 bucket and cloudfront domain (without path) for static files
-```
-AWS_STORAGE_BUCKET_NAME
-AWS_S3_CUSTOM_DOMAIN
-```
-
-#### postgres connection information
-```
-DB_HOST
-DB_NAME
-DB_PASSWORD
-DB_USER
+Run the development server.
+```sh
+$ docker-compose up
 ```
 
-#### url route to microservice (ie. /crowdsourcing)
-```
-DJANGO_URL_PREFIX
-```
-
-#### securely generated secret key
-```
-DJANGO_SECRET_KEY
+Run the migrations.
+```sh
+$ docker-compose exec django manage.py migrate
 ```
 
-#### sentry project
+Create a superuser.
+```sh
+$ docker-compose exec django manage.py createsuperuser
 ```
-SENTRY_DSN
+
+### Running tests
+
+Tests are executed via pytest using NYPR's setuptools extensions.
+Use `exec` to run tests on running development containers and `run` to run tests within a new container.
+```sh
+$ docker-compose exec python setup.py test
 ```
+
+For faster testing in development, test dependencies can be permanently
+installed.
+```sh
+$ docker-compose exec python setup.py test_requirements
+```
+
+### Interactive debugging
+
+To enable `ipdb` breakpoints developers need to attach to the Docker container
+running the Django development server.
+
+Start the containers and detach from the log output.
+```sh
+$ docker-compose up -d
+```
+
+If using `ipdb` for debugging it will need to be installed in the development container.
+```sh
+$ docker-compose exec django pip install ipdb
+```
+
+Attach to the container. The example below provides the likely name for the Django
+container, but if incorrect it can be obtained via `docker-compose ps`.
+```sh
+$ docker attach crowdsourcing_django_1
+```
+
+## Configuration
+
+Configuration should be set via environment variables.
+
+| **Config Value**          | **Description**                                 |
+| ------------------------- | ----------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`       | _Set via boto3 config or environment variable._ |
+| `AWS_DEFAULT_REGION`      | _Set via boto3 config or environment variable._ |
+| `AWS_SECRET_ACCESS_KEY`   | _Set via boto3 config or environment variable._ |
+| `AWS_S3_CUSTOM_DOMAIN`    | Cloudfront domain alias for static files.       |
+| `AWS_STORAGE_BUCKET_NAME` | S3 bucket for Django's storage backend.         |
+| `DB_HOST`                 | IP or hostname of the database.                 |
+| `DB_NAME`                 | Database name (for app, not tests).             |
+| `DB_PASSWORD`             | Database password (for app, not tests).         |
+| `DB_USER`                 | Database user (for app, not tests).             |
+| `DJANGO_URL_PREFIX`       | URL route to service (/crowdsourcing in prod).  |
+| `DJANGO_SECRET_KEY`       | Securely generated key for internal Django use. |
+| `SENTRY_DSN`              | URL for reporting uncaught exceptions.          |

--- a/circle.yml
+++ b/circle.yml
@@ -2,89 +2,75 @@ version: 2
 jobs:
 
   test:
-    working_directory: /code
+    working_directory: ~/crowdsourcing
     docker:
-      - image: python:3.6
+      - image: circleci/python:3.6
       - image: postgres
         name: db
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum "setup.py" }}
+          key: d-{{ checksum "setup.py" }}
       - run:
           name: Install Requirements
           command: |
-            if [[ ! -d /code/.venv ]]; then
-              python -m venv /code/.venv
-              . /code/.venv/bin/activate
-              python setup.py develop
+            if [[ ! -d ~/.venv ]]; then
+              python -m venv ~/.venv
+              . ~/.venv/bin/activate
+              pip install -e .
+              python setup.py test_requirements
             fi
       - run:
           name: Test
           command: |
-            . /code/.venv/bin/activate
+            . ~/.venv/bin/activate
             python setup.py test
       - save_cache:
-          key: deps-{{ checksum "setup.py" }}
+          key: d-{{ checksum "setup.py" }}
           paths:
-            - /code/.venv
-            - /code/.eggs
+            - ~/.venv
+            - ~/.eggs
+            - ~/crowdsourcing/crowdsourcing.egg-info
   deploy:
     working_directory: ~/crowdsourcing
     docker:
-      - image: docker:17.07.0-ce-git
+      - image: circleci/python:3.6
     steps:
       - checkout
       - setup_remote_docker
       - restore_cache:
-          key: deploy-{{ checksum "setup.py" }}
-      - run:
-          name: Install Requirements
-          command: |
-            apk add --no-cache python3
+          key: d-{{ checksum "setup.py" }}
       - run:
           name: Deploy
           command: |
+            . ~/.venv/bin/activate
             if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-              python3 setup.py deploy --environment=demo \
+              python setup.py deploy --environment=demo \
                                      --tag=demo \
                                      --ecs-cluster=microservices \
                                      --ecr-repository=crowdsourcing \
                                      --wait=300
             elif echo "$CIRCLE_TAG" | grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+"; then
-              python3 setup.py deploy --environment=prod \
+              python setup.py deploy --environment=prod \
                                      --tag="$CIRCLE_TAG" \
                                      --ecs-cluster=microservices \
                                      --ecr-repository=crowdsourcing \
                                      --wait=300
              fi
-      - save_cache:
-          key: deploy-{{ checksum "setup.py" }}
-          paths:
-            - ~/crowdsourcing/.eggs
-            - ~/.cache
 
   deploy_static:
-    working_directory: /code
+    working_directory: ~/crowdsourcing
     docker:
-      - image: python:3.6
+      - image: circleci/python:3.6
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum "setup.py" }}
-      - run:
-          name: Install Requirements
-          command: |
-            if [[ ! -d /code/.venv ]]; then
-              python -m venv /code/.venv
-              . /code/.venv/bin/activate
-              python setup.py requirements
-            fi
+          key: d-{{ checksum "setup.py" }}
       - run:
           name: Deploy Static
           command: |
-            . /code/.venv/bin/activate
-            python setup.py develop
+            . ~/.venv/bin/activate
+            pip install -e .
             set -o allexport
             if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
               env | grep ^DEMO_ | sed 's/DEMO_//g' > .env && source .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,18 @@ services:
     image: postgres
   django:
     build: .
-    image: nypr-crowdsourcing
     command: python3 manage.py runserver 0.0.0.0:8080
+    depends_on:
+      - db
     environment:
       DJANGO_DEBUG: "true"
       DJANGO_SECRET_KEY: dev
-    volumes:
-      - .:/code
+    image: nypr-crowdsourcing
+    links:
+      - db
     ports:
       - "8080:8080"
-    depends_on:
-      - db
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/code

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,22 @@
+[pytest]
+django_find_project = false
+addopts = -l -s --cov=crowdsourcing --cov=surveys --cov-report term-missing --flake8
+python_files = tests.py test_*.py *_tests.py
+env =
+    AWS_ACCESS_KEY_ID=TEST_AWS_ACCESS_KEY_ID
+    AWS_DEFAULT_REGION=us-east-1
+    AWS_SECRET_ACCESS_KEY=TEST_AWS_SECRET_ACCESS_KEY
+    AWS_STORAGE_BUCKET_NAME=TEST_STORAGE_BUCKET_NAME
+    AWS_S3_CUSTOM_DOMAIN=
+    DB_HOST=db
+    DB_NAME=postgres
+    DB_PASSWORD=
+    DB_USER=postgres
+    DJANGO_URL_PREFIX=
+    DJANGO_SECRET_KEY=TEST_SECRET_KEY
+    DJANGO_SETTINGS_MODULE=crowdsourcing.settings
+    SENTRY_DSN=
+flake8-max-line-length = 119
+flake8-ignore =
+    manage.py F401
+    surveys/migrations/* ALL

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,6 @@
 NYPR Crowdsourcing
 """
 from setuptools import setup
-try:
-    import nyprsetuptools
-except ImportError:
-    import pip
-    pip.main(['install', '-U', 'git+https://github.com/nypublicradio/nyprsetuptools.git'])
-    import nyprsetuptools
-
 
 setup(
     name='crowdsourcing',
@@ -46,6 +39,12 @@ setup(
         'uwsgi',
     ],
     tests_require=[
+        'pytest>=3.0.6',
+        'pytest-cov',
+        'pytest-django',
+        'pytest-env',
+        'pytest-flake8',
+        'pytest-sugar',
         'coverage',
         'ipdb',
         'mixer',
@@ -55,9 +54,24 @@ setup(
         "scripts/run_prod",
         "manage.py"
     ],
-    cmdclass={
-        'deploy': nyprsetuptools.DockerDeploy,
-        'requirements': nyprsetuptools.InstallRequirements,
-        'test': nyprsetuptools.DjangoTest,
-    }
+    setup_requires=[
+        'nyprsetuptools>=0.0.0'
+    ],
+    dependency_links=[
+        'https://github.com/nypublicradio/nyprsetuptools/tarball/master#egg=nyprsetuptools-0.0.0'
+    ],
+    entry_points={
+        'distutils.commands': [
+            'requirements = nyprsetuptools:InstallRequirements',
+            'test = nyprsetuptools:PyTest',
+            'test_requirements = nyprsetuptools:InstallTestRequirements',
+            'deploy = nyprsetuptools:DockerDeploy',
+        ],
+        'distutils.setup_keywords': [
+            'requirements = nyprsetuptools:setup_keywords',
+            'test = nyprsetuptools:setup_keywords',
+            'test_requirements = nyprsetuptools:setup_keywords',
+            'deploy = nyprsetuptools:setup_keywords',
+        ],
+    },
 )

--- a/surveys/tests.py
+++ b/surveys/tests.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import Mock, patch
 
+import pytest
 from django.urls import reverse
 
 from mixer.backend.django import mixer
@@ -9,6 +10,9 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from surveys.models import Survey, Question, Submission
+
+
+pytestmark = pytest.mark.django_db
 
 
 class SubmissionTests(APITestCase):


### PR DESCRIPTION
This commit provides access to Django's testrunner via setuptools (to enable on-demand test dependency installation).

Django tests will run via pytest-django which offers better fixtures and integration with extensions.
Extensions we use:
* pytest-cov (for coverage reports)
* pytest-env (to enforce test environment variables)
* pytest-flake8 (for PEP8 compliance and syntax error detection)
* pytest-sugar (for more human-readable test reports)

The circle workflow was modified to use Circle's images (to enable cache-sharing throughout all workflow steps). Tests should have faster initialization times with Circle's image, but will be slower overall due to the addition of coverage and flake8 checks. Tests will still be fast locally because flake8 caches results based on a file's modification time.