### PR TITLE
avoids docker-compose mounts that cause local artifacts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,10 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - .:/code
+      - ./crowdsourcing:/code/crowdsourcing
+      - ./scripts:/code/scripts
+      - ./surveys:/code/surveys
+      - ./templates:/code/templates 
+      - ./manage.py:/code/manage.py
+      - ./setup.py:/code/setup.py
+      - ./pytest.ini:/code/pytest.ini


### PR DESCRIPTION
When mounting the entire code directory python artifacts are written to
a user's local filesystem. These files persist and can cause errors in
state over time.